### PR TITLE
fix: handle add to dictionary command

### DIFF
--- a/lua/ltex-ls/init.lua
+++ b/lua/ltex-ls/init.lua
@@ -183,7 +183,7 @@ local commands = {
 --- Setup ltex-ls to integrate with neovim
 --- This assumes that config matches what lspconfig expects
 function M.setup(user_config)
-  vim.lsp.commands["_ltex.addToDictionnary"] = mk_command_handler(function(cmd, args, client)
+  vim.lsp.commands["_ltex.addToDictionary"] = mk_command_handler(function(cmd, args, client)
     handlers.handle_option_update(client, "dictionary", args.words)
   end)
   vim.lsp.commands["_ltex.hideFalsePositives"] = mk_command_handler(function(cmd, args, client)


### PR DESCRIPTION
There's a typo in trying to handle the add to dictionary commands.
With this fix the code action is working again.